### PR TITLE
Adding documentation to describe logging in to the Kubernetes dashboard

### DIFF
--- a/fragments/k8s/cdk-converged/README.md
+++ b/fragments/k8s/cdk-converged/README.md
@@ -166,8 +166,8 @@ kubectl cluster-info
 
 ### Accessing the Kubernetes dashboard
 
-The Kubernetes dashboard addon is installed by default, along with Heapster,
-Grafana and InfluxDB for cluster monitoring. The dashboard addons can be
+The Kubernetes dashboard addon is installed by default, along with Metrics Server,
+Heapster, Grafana and InfluxDB for cluster monitoring. The dashboard addons can be
 enabled or disabled by setting the `enable-dashboard-addons` config on the
 `kubernetes-master` application:
 
@@ -185,6 +185,9 @@ kubectl proxy
 By default, this establishes a proxy running on your local machine and the
 kubernetes-master unit. To reach the Kubernetes dashboard, visit
 `http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/`
+
+Logging in to the dashboard will require either a valid kubeconfig or a basic auth
+username and password.
 
 ### Control the cluster
 

--- a/fragments/k8s/cdk/README.md
+++ b/fragments/k8s/cdk/README.md
@@ -161,8 +161,8 @@ kubectl cluster-info
 
 ### Accessing the Kubernetes dashboard
 
-The Kubernetes dashboard addon is installed by default, along with Heapster,
-Grafana and InfluxDB for cluster monitoring. The dashboard addons can be
+The Kubernetes dashboard addon is installed by default, along with Metrics Server,
+Heapster, Grafana and InfluxDB for cluster monitoring. The dashboard addons can be
 enabled or disabled by setting the `enable-dashboard-addons` config on the
 `kubernetes-master` application:
 
@@ -180,6 +180,9 @@ kubectl proxy
 By default, this establishes a proxy running on your local machine and the
 kubernetes-master unit. To reach the Kubernetes dashboard, visit
 `http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/`
+
+Logging in to the dashboard will require either a valid kubeconfig or a basic auth
+username and password.
 
 ### Control the cluster
 

--- a/fragments/k8s/core/README.md
+++ b/fragments/k8s/core/README.md
@@ -149,8 +149,8 @@ kubectl cluster-info
 
 ### Accessing the Kubernetes Dashboard
 
-The Kubernetes dashboard addon is installed by default, along with Heapster,
-Grafana and InfluxDB for cluster monitoring. The dashboard addons can be
+The Kubernetes dashboard addon is installed by default, along with Metrics Server,
+Heapster, Grafana and InfluxDB for cluster monitoring. The dashboard addons can be
 enabled or disabled by setting the `enable-dashboard-addons` config on the
 `kubernetes-master` application:
 
@@ -168,6 +168,9 @@ kubectl proxy
 By default, this establishes a proxy running on your local machine and the
 kubernetes-master unit. To reach the Kubernetes dashboard, visit
 `http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/`
+
+Logging in to the dashboard will require either a valid kubeconfig or a basic auth
+username and password.
 
 ### Control the cluster
 


### PR DESCRIPTION
Just a little blurb saying that logging is now required for the Kubernetes dashboard.