### PR TITLE
New layout after addition of subordinate runtimes

### DIFF
--- a/fragments/cni/calico/bundle.yaml
+++ b/fragments/cni/calico/bundle.yaml
@@ -3,8 +3,8 @@ services:
   "calico":
     charm: "cs:~containers/calico"
     annotations:
-      "gui-x": "450"
-      "gui-y": "750"
+      "gui-x": "475"
+      "gui-y": "605"
 relations:
   - - "calico:etcd"
     - "etcd:db"

--- a/fragments/cni/canal/bundle.yaml
+++ b/fragments/cni/canal/bundle.yaml
@@ -3,8 +3,8 @@ services:
   "canal":
     charm: "cs:~containers/canal"
     annotations:
-      "gui-x": "450"
-      "gui-y": "750"
+      "gui-x": "475"
+      "gui-y": "605"
 relations:
   - - "canal:etcd"
     - "etcd:db"

--- a/fragments/cni/flannel/bundle.yaml
+++ b/fragments/cni/flannel/bundle.yaml
@@ -3,8 +3,8 @@ services:
   "flannel":
     charm: "cs:~containers/flannel"
     annotations:
-      "gui-x": "450"
-      "gui-y": "750"
+      "gui-x": "475"
+      "gui-y": "605"
 relations:
   - - "flannel:etcd"
     - "etcd:db"

--- a/fragments/cri/containerd/bundle.yaml
+++ b/fragments/cri/containerd/bundle.yaml
@@ -2,6 +2,9 @@
 services:
   "containerd":
     charm: cs:~containers/containerd
+    annotations:
+      "gui-x": "475"
+      "gui-y": "800"
 relations:
 - - containerd:containerd
   - kubernetes-worker:container-runtime

--- a/fragments/cri/docker/bundle.yaml
+++ b/fragments/cri/docker/bundle.yaml
@@ -2,6 +2,9 @@
 services:
   "docker":
     charm: cs:~containers/docker
+    annotations:
+      "gui-x": "475"
+      "gui-y": "800"
 relations:
 - - docker:docker
   - kubernetes-worker:container-runtime

--- a/fragments/k8s/cdk-converged/bundle.yaml
+++ b/fragments/k8s/cdk-converged/bundle.yaml
@@ -43,8 +43,8 @@ services:
     charm: "cs:~containers/easyrsa"
     num_units: 1
     annotations:
-      "gui-x": "450"
-      "gui-y": "550"
+      "gui-x": "90"
+      "gui-y": "420"
     to:
      - lxd:kubernetes-master
   "kubernetes-worker":
@@ -55,7 +55,7 @@ services:
       channel: 1.15/stable
     expose: true
     annotations:
-      "gui-x": "100"
+      "gui-x": "90"
       "gui-y": "850"
     to: ["kvm:kubernetes-worker-host/0",
         "kvm:kubernetes-worker-host/1",
@@ -74,7 +74,7 @@ services:
     num_units: 3
     annotations:
       "gui-x": "800"
-      "gui-y": "550"
+      "gui-y": "420"
     to:
         - 0
         - 1
@@ -83,8 +83,8 @@ services:
     charm: "cs:ubuntu"
     num_units: 4
     annotations:
-      "gui-x": "200"
-      "gui-y": "250"
+      "gui-x": "90"
+      "gui-y": "850"
     to:
         - 3
         - 4

--- a/fragments/k8s/cdk/bundle.yaml
+++ b/fragments/k8s/cdk/bundle.yaml
@@ -25,8 +25,8 @@ services:
     num_units: 1
     constraints: "root-disk=8G"
     annotations:
-      "gui-x": "450"
-      "gui-y": "550"
+      "gui-x": "90"
+      "gui-y": "420"
   "kubernetes-worker":
     charm: "cs:~containers/kubernetes-worker"
     num_units: 3
@@ -35,7 +35,7 @@ services:
     expose: true
     constraints: "cores=4 mem=4G root-disk=16G"
     annotations:
-      "gui-x": "100"
+      "gui-x": "90"
       "gui-y": "850"
   "etcd":
     charm: "cs:~containers/etcd"
@@ -45,7 +45,7 @@ services:
     constraints: "root-disk=8G"
     annotations:
       "gui-x": "800"
-      "gui-y": "550"
+      "gui-y": "420"
 relations:
   - - "kubernetes-master:kube-api-endpoint"
     - "kubeapi-load-balancer:apiserver"

--- a/fragments/k8s/core/bundle.yaml
+++ b/fragments/k8s/core/bundle.yaml
@@ -21,8 +21,8 @@ services:
     to:
       - lxd:0
     annotations:
-      "gui-x": "450"
-      "gui-y": "550"
+      "gui-x": "90"
+      "gui-y": "420"
   "kubernetes-worker":
     charm: "cs:~containers/kubernetes-worker"
     num_units: 1
@@ -33,7 +33,7 @@ services:
     expose: true
     constraints: "cores=4 mem=4G root-disk=16G"
     annotations:
-      "gui-x": "100"
+      "gui-x": "90"
       "gui-y": "850"
   "etcd":
     charm: "cs:~containers/etcd"
@@ -44,7 +44,7 @@ services:
       - "0"
     annotations:
       "gui-x": "800"
-      "gui-y": "550"
+      "gui-y": "420"
 relations:
   - - "kubernetes-master:kube-api-endpoint"
     - "kubernetes-worker:kube-api-endpoint"


### PR DESCRIPTION
![ck](https://user-images.githubusercontent.com/1426404/61482859-96e8a500-a969-11e9-9b91-784893220b3f.png)

Re-shuffle the layout to accommodate container runtime subordinate.

https://bugs.launchpad.net/charm-containerd/+bug/1837039