### PR TITLE
Add vault-pki-overlay.yaml from docs

### DIFF
--- a/overlays/vault-pki-overlay.yaml
+++ b/overlays/vault-pki-overlay.yaml
@@ -1,0 +1,19 @@
+applications:
+  easyrsa: null
+  vault:
+    charm: cs:~openstack-charmers-next/vault
+    num_units: 1
+    options:
+      auto-generate-root-ca-cert: true
+  percona-cluster:
+    charm: cs:percona-cluster
+    num_units: 1
+relations:
+- - kubernetes-master:certificates
+  - vault:certificates
+- - etcd:certificates
+  - vault:certificates
+- - kubernetes-worker:certificates
+  - vault:certificates
+- - vault:shared-db
+  - percona-cluster:shared-db


### PR DESCRIPTION
The bundle overlays are being moved out of the docs repo and into the bundle repo.