### PR TITLE
add elastic/graylog/filebeat overlay

### DIFF
--- a/overlays/logging-egf-overlay.yaml
+++ b/overlays/logging-egf-overlay.yaml
@@ -1,0 +1,36 @@
+applications:
+  apache2:
+    charm: cs:bionic/apache2-26
+    num_units: 1
+    expose: true
+    options:
+      enable_modules: "headers proxy_html proxy_http"
+  elasticsearch:
+    charm: cs:bionic/elasticsearch-39
+    constraints: mem=7G root-disk=16G
+    num_units: 1
+    options:
+      apt-repository: "deb https://artifacts.elastic.co/packages/6.x/apt stable main"
+  filebeat:
+    charm: cs:bionic/filebeat-29
+    options:
+      install_sources: "deb https://artifacts.elastic.co/packages/6.x/apt stable main"
+      kube_logs: True
+  graylog:
+    charm: cs:bionic/graylog-39
+    constraints: mem=7G root-disk=16G
+    num_units: 1
+    options:
+      channel: "3/stable"
+  mongodb:
+    charm: cs:bionic/mongodb-53
+    num_units: 1
+    options:
+      extra_daemon_options: "--bind_ip_all"
+relations:
+  - ["apache2:reverseproxy", "graylog:website"]
+  - ["graylog:elasticsearch", "elasticsearch:client"]
+  - ["graylog:mongodb", "mongodb:database"]
+  - ["filebeat:beats-host", "kubernetes-master:juju-info"]
+  - ["filebeat:beats-host", "kubernetes-worker:juju-info"]
+  - ["filebeat:logstash", "graylog:beats"]


### PR DESCRIPTION
The ELK stack is now at v6 and graylog officially supports v3.  Rich k8s metadata can now be collected with a simple overlay.

Fixes #651