### PR TITLE
Etcd 3.3 by default

### DIFF
--- a/fragments/k8s/cdk/bundle.yaml
+++ b/fragments/k8s/cdk/bundle.yaml
@@ -41,7 +41,7 @@ services:
     charm: "cs:~containers/etcd"
     num_units: 3
     options:
-      channel: 3.2/stable
+      channel: 3.3/stable
     constraints: "root-disk=8G"
     annotations:
       "gui-x": "800"

--- a/fragments/k8s/core/bundle.yaml
+++ b/fragments/k8s/core/bundle.yaml
@@ -39,7 +39,7 @@ services:
     charm: "cs:~containers/etcd"
     num_units: 1
     options:
-      channel: 3.2/stable
+      channel: 3.3/stable
     to:
       - "0"
     annotations:


### PR DESCRIPTION
Tested with overlay.  Have run etcd validation tests against 3.3 and they pass.