### PR TITLE
default to latest stable charms in logging overlay

### DIFF
--- a/overlays/logging-egf-overlay.yaml
+++ b/overlays/logging-egf-overlay.yaml
@@ -1,29 +1,29 @@
 applications:
   apache2:
-    charm: cs:bionic/apache2-26
+    charm: cs:bionic/apache2
     num_units: 1
     expose: true
     options:
       enable_modules: "headers proxy_html proxy_http"
   elasticsearch:
-    charm: cs:bionic/elasticsearch-39
+    charm: cs:bionic/elasticsearch
     constraints: mem=7G root-disk=16G
     num_units: 1
     options:
       apt-repository: "deb https://artifacts.elastic.co/packages/6.x/apt stable main"
   filebeat:
-    charm: cs:bionic/filebeat-29
+    charm: cs:bionic/filebeat
     options:
       install_sources: "deb https://artifacts.elastic.co/packages/6.x/apt stable main"
       kube_logs: True
   graylog:
-    charm: cs:bionic/graylog-39
+    charm: cs:bionic/graylog
     constraints: mem=7G root-disk=16G
     num_units: 1
     options:
       channel: "3/stable"
   mongodb:
-    charm: cs:bionic/mongodb-53
+    charm: cs:bionic/mongodb
     num_units: 1
     options:
       extra_daemon_options: "--bind_ip_all"


### PR DESCRIPTION
Related to https://bugs.launchpad.net/cdk-addons/+bug/1858651.  Stop locking charm revisions in our logging overlay since we always want latest stable charms.