### PR TITLE
Add missing kube-api-endpoint relation in OpenStack LB overlay

### DIFF
--- a/overlays/openstack-lb-overlay.yaml
+++ b/overlays/openstack-lb-overlay.yaml
@@ -8,6 +8,7 @@ applications:
     num_units: 1
     trust: true
 relations:
+  - ['kubernetes-master:kube-api-endpoint', 'kubernetes-worker:kube-api-endpoint']
   - ['openstack-integrator', 'kubernetes-master:loadbalancer']
   - ['openstack-integrator', 'kubernetes-master:openstack']
   - ['openstack-integrator', 'kubernetes-worker:openstack']


### PR DESCRIPTION
The kube-api-endpoint relation was originally being proxied between k8s-master and k8s-worker via kubeapi-load-balancer, but with that being removed, needs to be directly established between the master and worker.