### PR TITLE
Update ceph-fs overlay to match ceph-rbd

### DIFF
--- a/overlays/ceph-fs.yaml
+++ b/overlays/ceph-fs.yaml
@@ -11,9 +11,9 @@ applications:
     num_units: 3
     series: bionic
     storage:
-      osd-devices: '10G'
+      osd-devices: '32G,2'
+      osd-journals: '8G,1'
     options:
-      osd-devices: '/dev/test-non-existent'
       source: cloud:bionic-train
   ceph-mon:
     charm: cs:ceph-mon


### PR DESCRIPTION
There was a mismatch between the storage settings in the ceph-fs overlay vs ceph-rbd, and the former also had an errant test value in the options for `osd-devices`.