### PR TITLE
Update issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,1 +1,1 @@
-*If your deployment is broken and you'd like help debugging it, please run our [CDK Field Agent](https://github.com/juju-solutions/cdk-field-agent) tool and attach the resulting tarball to this issue.*
+Please file new issues at https://bugs.launchpad.net/charmed-kubernetes.


### PR DESCRIPTION
I noticed from https://github.com/charmed-kubernetes/bundle/issues/771 that some bug reporters are still seeing the old issue template. I can reproduce it if I go to Issues -> New Issues -> "Open a blank issue" (which takes you [here](https://github.com/charmed-kubernetes/bundle/issues/new)).

This updates the default issue template to match the one in [.github/ISSUE_TEMPLATE/bug_report.md](https://github.com/charmed-kubernetes/bundle/blob/master/.github/ISSUE_TEMPLATE/bug_report.md).