### PR TITLE
Deprecate yaml.load()

### DIFF
--- a/bundle
+++ b/bundle
@@ -198,7 +198,7 @@ def main():
         print('Processing fragment %s...' % frag)
         paths = fragment_paths(frag)
         with open(paths['bundle'], 'r') as f:
-            frag_bundle = yaml.load(f)
+            frag_bundle = yaml.safe_load(f)
         merge(frag_bundle, bundle)
         with open(paths['readme'], 'r') as f:
             frag_readme = f.read()


### PR DESCRIPTION
Avoid deprecation warning
...bundle:201: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.