### PR TITLE
new edge bundles should come from 1.22/edge

### DIFF
--- a/fragments/k8s/cdk-converged/README.md
+++ b/fragments/k8s/cdk-converged/README.md
@@ -1,6 +1,6 @@
 # The Charmed Distribution of Kubernetes (converged)
 
-![](https://img.shields.io/badge/kubernetes-1.20-brightgreen.svg) ![](https://img.shields.io/badge/juju-2.0+-brightgreen.svg)
+![](https://img.shields.io/badge/kubernetes-1.22-brightgreen.svg) ![](https://img.shields.io/badge/juju-2.0+-brightgreen.svg)
 
 ## Overview
 

--- a/fragments/k8s/cdk-converged/bundle.yaml
+++ b/fragments/k8s/cdk-converged/bundle.yaml
@@ -22,7 +22,7 @@ services:
     charm: "cs:~containers/kubernetes-master"
     num_units: 3
     options:
-      channel: 1.20/stable
+      channel: 1.22/edge
     annotations:
       "gui-x": "800"
       "gui-y": "850"
@@ -52,7 +52,7 @@ services:
     constraints: cores=2 mem=4G root-disk=30G
     num_units: 12
     options:
-      channel: 1.20/stable
+      channel: 1.22/edge
     expose: true
     annotations:
       "gui-x": "90"

--- a/fragments/k8s/cdk/README.md
+++ b/fragments/k8s/cdk/README.md
@@ -1,6 +1,6 @@
 # The Charmed Distribution of Kubernetes
 
-![](https://img.shields.io/badge/kubernetes-1.20-brightgreen.svg) ![](https://img.shields.io/badge/juju-2.0+-brightgreen.svg)
+![](https://img.shields.io/badge/kubernetes-1.22-brightgreen.svg) ![](https://img.shields.io/badge/juju-2.0+-brightgreen.svg)
 
 ## Overview
 

--- a/fragments/k8s/cdk/bundle.yaml
+++ b/fragments/k8s/cdk/bundle.yaml
@@ -7,7 +7,7 @@ services:
     charm: "cs:~containers/kubernetes-master"
     num_units: 2
     options:
-      channel: 1.20/stable
+      channel: 1.22/edge
     constraints: "cores=2 mem=4G root-disk=16G"
     annotations:
       "gui-x": "800"
@@ -31,7 +31,7 @@ services:
     charm: "cs:~containers/kubernetes-worker"
     num_units: 3
     options:
-      channel: 1.20/stable
+      channel: 1.22/edge
     expose: true
     constraints: "cores=4 mem=4G root-disk=16G"
     annotations:

--- a/fragments/k8s/core/README.md
+++ b/fragments/k8s/core/README.md
@@ -1,6 +1,6 @@
 # Kubernetes Core Bundle
 
-![](https://img.shields.io/badge/kubernetes-1.20-brightgreen.svg) ![](https://img.shields.io/badge/juju-2.0+-brightgreen.svg)
+![](https://img.shields.io/badge/kubernetes-1.22-brightgreen.svg) ![](https://img.shields.io/badge/juju-2.0+-brightgreen.svg)
 
 ## Overview
 

--- a/fragments/k8s/core/bundle.yaml
+++ b/fragments/k8s/core/bundle.yaml
@@ -9,7 +9,7 @@ services:
     to:
       - "0"
     options:
-      channel: 1.20/stable
+      channel: 1.22/edge
     expose: true
     constraints: "cores=2 mem=4G root-disk=16G"
     annotations:
@@ -29,7 +29,7 @@ services:
     to:
       - "1"
     options:
-      channel: 1.20/stable
+      channel: 1.22/edge
     expose: true
     constraints: "cores=4 mem=4G root-disk=16G"
     annotations:


### PR DESCRIPTION
1.21 is now stable. Per [release doc](http://jenkaas.s3-website-us-east-1.amazonaws.com/docs/releases/stable/#update-ck-bundle-repo-references), edge bundles from master branch should move up to 1.22.