### PR TITLE
services->applications

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -93,7 +93,7 @@ Each fragment is simply a bundle with two constraints:
 Here's a simple example from the `flannel` fragment:
 
 ```yaml
-services:
+applications:
   "flannel":
     charm: "cs:~containers/flannel"
 relations:

--- a/bundle
+++ b/bundle
@@ -109,9 +109,9 @@ def merge(src, dst):
 def local_bundle(bundle, root):
     ''' Build bundle using local paths for charms. '''
     copy = json.loads(json.dumps(bundle))
-    for service in bundle['services']:
-        charm = bundle['services'][service]['charm'].strip().split('/')[-1]
-        copy['services'][service]['charm'] = os.path.join(root, charm)
+    for application in bundle['applications']:
+        charm = bundle['applications'][application]['charm'].strip().split('/')[-1]
+        copy['applications'][application]['charm'] = os.path.join(root, charm)
     return copy
 
 
@@ -120,12 +120,12 @@ def version_bundle(bundle, channel, overrides):
     copy = json.loads(json.dumps(bundle))
 
     # pin charm revisions
-    for service in bundle['services']:
-        charm = bundle['services'][service]['charm']
+    for application in bundle['applications']:
+        charm = bundle['applications'][application]['charm']
         for override in overrides:
             name, revision = override.split(',')
             if name == charm:
-                copy['services'][service]['charm'] = name + '-' + revision
+                copy['applications'][application]['charm'] = name + '-' + revision
                 break
         else:
             resp = requests.get('https://api.jujucharms.com/charmstore/v5/meta/id',
@@ -135,22 +135,22 @@ def version_bundle(bundle, channel, overrides):
                 raise CharmstoreQueryError(err)
             meta = resp.json()
             meta = [meta[k] for k in meta][0]
-            copy['services'][service]['charm'] = meta['Id']
+            copy['applications'][application]['charm'] = meta['Id']
 
     # pin resource revisions
-    for service in bundle['services']:
-        charm = bundle['services'][service]['charm']
+    for application in bundle['applications']:
+        charm = bundle['applications'][application]['charm']
         resp = requests.get('https://api.jujucharms.com/charmstore/v5/meta/resources',
                             params={'id': charm, 'channel': channel})
         if not resp.ok:
             err = "Couldn't query resources for %s %s, is it public?" % (charm, channel)
             raise CharmstoreQueryError(err)
         response_data = resp.json()
-        copy['services'][service].setdefault('resources', {})
+        copy['applications'][application].setdefault('resources', {})
         for resource in response_data[charm]:
             name = resource['Name']
             revision = resource['Revision']
-            copy['services'][service]['resources'][name] = revision
+            copy['applications'][application]['resources'][name] = revision
 
     return copy
 
@@ -163,11 +163,11 @@ def yaml_lines(data):
 def serialize(bundle):
     ''' Serialize a bundle in a conventional form. '''
     relations = {}
-    services = {}
+    applications = {}
     otherwise = []
     for k, v in bundle.items():
-        if k == 'services':
-            services['services'] = v
+        if k == 'applications':
+            applications['applications'] = v
         elif k == 'relations':
             relations['relations'] = v
         else:
@@ -176,8 +176,8 @@ def serialize(bundle):
     out = ''
     for o in otherwise:
         out += yaml.dump(o, default_flow_style=False, width=1000)
-    if bool(services):
-        out += yaml.dump(services, default_flow_style=False, width=1000)
+    if bool(applications):
+        out += yaml.dump(applications, default_flow_style=False, width=1000)
     if bool(relations):
         out += yaml.dump(relations, default_flow_style=False, width=1000)
     return out

--- a/fragments/cni/calico/bundle.yaml
+++ b/fragments/cni/calico/bundle.yaml
@@ -1,5 +1,5 @@
 # This is an incomplete bundle fragment. Do not attempt to deploy.
-services:
+applications:
   "calico":
     charm: "cs:~containers/calico"
     annotations:

--- a/fragments/cni/canal/bundle.yaml
+++ b/fragments/cni/canal/bundle.yaml
@@ -1,5 +1,5 @@
 # This is an incomplete bundle fragment. Do not attempt to deploy.
-services:
+applications:
   "canal":
     charm: "cs:~containers/canal"
     annotations:

--- a/fragments/cni/flannel/bundle.yaml
+++ b/fragments/cni/flannel/bundle.yaml
@@ -1,5 +1,5 @@
 # This is an incomplete bundle fragment. Do not attempt to deploy.
-services:
+applications:
   "flannel":
     charm: "cs:~containers/flannel"
     annotations:

--- a/fragments/cni/tigera-secure-ee/bundle.yaml
+++ b/fragments/cni/tigera-secure-ee/bundle.yaml
@@ -1,5 +1,5 @@
 # This is an incomplete bundle fragment. Do not attempt to deploy.
-services:
+applications:
   tigera-secure-ee:
     charm: "cs:~containers/tigera-secure-ee"
     annotations:

--- a/fragments/cri/containerd/bundle.yaml
+++ b/fragments/cri/containerd/bundle.yaml
@@ -1,5 +1,5 @@
 # This is an incomplete bundle fragment. Do not attempt to deploy.
-services:
+applications:
   "containerd":
     charm: cs:~containers/containerd
     annotations:

--- a/fragments/cri/docker/bundle.yaml
+++ b/fragments/cri/docker/bundle.yaml
@@ -1,5 +1,5 @@
 # This is an incomplete bundle fragment. Do not attempt to deploy.
-services:
+applications:
   "docker":
     charm: cs:~containers/docker
     annotations:

--- a/fragments/k8s/cdk-converged/bundle.yaml
+++ b/fragments/k8s/cdk-converged/bundle.yaml
@@ -17,7 +17,7 @@ machines:
     constraints: cores=12 mem=32G root-disk=200G
   6:
     constraints: cores=12 mem=32G root-disk=200G
-services:
+applications:
   "kubernetes-master":
     charm: "cs:~containers/kubernetes-master"
     num_units: 3

--- a/fragments/k8s/cdk/bundle.yaml
+++ b/fragments/k8s/cdk/bundle.yaml
@@ -2,7 +2,7 @@
 description: |-
     A highly-available, production-grade Kubernetes cluster.
 series: focal
-services:
+applications:
   "kubernetes-master":
     charm: "cs:~containers/kubernetes-master"
     num_units: 2

--- a/fragments/k8s/core/bundle.yaml
+++ b/fragments/k8s/core/bundle.yaml
@@ -2,7 +2,7 @@
 description: |-
     A minimal two-machine Kubernetes cluster, appropriate for development.
 series: focal
-services:
+applications:
   "kubernetes-master":
     charm: "cs:~containers/kubernetes-master"
     num_units: 1

--- a/fragments/legacy-storage/ceph/bundle.yaml
+++ b/fragments/legacy-storage/ceph/bundle.yaml
@@ -1,5 +1,5 @@
 # This is an incomplete bundle fragment. Do not attempt to deploy.
-services:
+applications:
   ceph-osd:
     charm: 'cs:ceph-osd'
     num_units: 3

--- a/fragments/monitor/elastic/bundle.yaml
+++ b/fragments/monitor/elastic/bundle.yaml
@@ -1,5 +1,5 @@
 # This is an incomplete bundle fragment. Do not attempt to deploy.
-services:
+applications:
   elasticsearch:
     charm: "cs:elasticsearch"
     constraints: mem=4G root-disk=16G


### PR DESCRIPTION
Juju 2.9 now emits warnings about the use of 'services' in bundles rather than applications [LP#1913779](https://bugs.launchpad.net/charmed-kubernetes-bundles/+bug/1913779)

We should switch to applications so we don't get warnings and the bundle continues to work in Juju 3.0