### PR TITLE
Qualify Azure integration relation endpoint

### DIFF
--- a/overlays/azure-overlay.yaml
+++ b/overlays/azure-overlay.yaml
@@ -8,5 +8,5 @@ applications:
     num_units: 1
     trust: true
 relations:
-  - ['azure-integrator', 'kubernetes-master']
-  - ['azure-integrator', 'kubernetes-worker']
+  - ['azure-integrator', 'kubernetes-master:azure']
+  - ['azure-integrator', 'kubernetes-worker:azure']


### PR DESCRIPTION
With the addition of the load balancer relation endpoints, the relation between k8s-master and the azure-integrator becomes ambiguous, so this qualifies it in the overlay.