### PR TITLE
Update ipFamily -> ipFamilies for k8s 1.20+

### DIFF
--- a/specs/nginx-dual-stack.yaml
+++ b/specs/nginx-dual-stack.yaml
@@ -26,7 +26,7 @@ metadata:
     run: nginxdualstack
 spec:
   type: NodePort
-  ipFamily: IPv6
+  ipFamilies: [IPv6]
   ports:
   - port: 80
     protocol: TCP


### PR DESCRIPTION
From the k8s 1.20 [changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md):

> Add dual-stack Services (alpha). This is a BREAKING CHANGE to an alpha API. It changes the dual-stack API wrt Service from a single ipFamily field to 3 fields: ipFamilyPolicy (SingleStack, PreferDualStack, RequireDualStack), ipFamilies (a list of families assigned), and clusterIPs (inclusive of clusterIP).