### PR TITLE
make 1.23/stable the default channel

### DIFF
--- a/fragments/k8s/cdk-converged/bundle.yaml
+++ b/fragments/k8s/cdk-converged/bundle.yaml
@@ -22,7 +22,7 @@ applications:
     charm: "cs:~containers/kubernetes-master"
     num_units: 3
     options:
-      channel: 1.23/edge
+      channel: 1.23/stable
     annotations:
       "gui-x": "800"
       "gui-y": "850"
@@ -52,7 +52,7 @@ applications:
     constraints: cores=2 mem=4G root-disk=30G
     num_units: 12
     options:
-      channel: 1.23/edge
+      channel: 1.23/stable
     expose: true
     annotations:
       "gui-x": "90"

--- a/fragments/k8s/cdk/bundle.yaml
+++ b/fragments/k8s/cdk/bundle.yaml
@@ -7,7 +7,7 @@ applications:
     charm: "cs:~containers/kubernetes-master"
     num_units: 2
     options:
-      channel: 1.23/edge
+      channel: 1.23/stable
     constraints: "cores=2 mem=4G root-disk=16G"
     annotations:
       "gui-x": "800"
@@ -31,7 +31,7 @@ applications:
     charm: "cs:~containers/kubernetes-worker"
     num_units: 3
     options:
-      channel: 1.23/edge
+      channel: 1.23/stable
     expose: true
     constraints: "cores=4 mem=4G root-disk=16G"
     annotations:

--- a/fragments/k8s/core/bundle.yaml
+++ b/fragments/k8s/core/bundle.yaml
@@ -9,7 +9,7 @@ applications:
     to:
       - "0"
     options:
-      channel: 1.23/edge
+      channel: 1.23/stable
     expose: true
     constraints: "cores=2 mem=4G root-disk=16G"
     annotations:
@@ -29,7 +29,7 @@ applications:
     to:
       - "1"
     options:
-      channel: 1.23/edge
+      channel: 1.23/stable
     expose: true
     constraints: "cores=4 mem=4G root-disk=16G"
     annotations:


### PR DESCRIPTION
In preparation for the 1.23 release, make 1.23/stable the default channel in the `stable` branch.