### PR TITLE
fix issue with inclusive naming in the kubernetes-core bundle 

### DIFF
--- a/fragments/k8s/core/bundle.yaml
+++ b/fragments/k8s/core/bundle.yaml
@@ -47,7 +47,7 @@ applications:
       "gui-y": "420"
 relations:
   - - "kubernetes-control-plane:kube-control"
-    - "kubernetes-control-plane:kube-control"
+    - "kubernetes-worker:kube-control"
   - - "kubernetes-control-plane:certificates"
     - "easyrsa:client"
   - - "kubernetes-control-plane:etcd"


### PR DESCRIPTION
related k8s-cp was to itself rather than k8s-worker