### PR TITLE
adjust snap channels and constraints for 1.24

### DIFF
--- a/fragments/k8s/cdk/bundle.yaml
+++ b/fragments/k8s/cdk/bundle.yaml
@@ -7,8 +7,8 @@ applications:
     charm: "kubernetes-control-plane"
     num_units: 2
     options:
-      channel: 1.23/edge
-    constraints: "cores=2 mem=4G root-disk=16G"
+      channel: 1.24/edge
+    constraints: "cores=2 mem=8G root-disk=16G"
     annotations:
       "gui-x": "800"
       "gui-y": "850"
@@ -16,14 +16,14 @@ applications:
     charm: "kubeapi-load-balancer"
     num_units: 1
     expose: true
-    constraints: "mem=4G root-disk=8G"
+    constraints: "cores=1 mem=4G root-disk=16G"
     annotations:
       "gui-x": "450"
       "gui-y": "250"
   "easyrsa":
     charm: "easyrsa"
     num_units: 1
-    constraints: "root-disk=8G"
+    constraints: "cores=1 mem=4G root-disk=16G"
     annotations:
       "gui-x": "90"
       "gui-y": "420"
@@ -31,9 +31,9 @@ applications:
     charm: "kubernetes-worker"
     num_units: 3
     options:
-      channel: 1.23/edge
+      channel: 1.24/edge
     expose: true
-    constraints: "cores=4 mem=4G root-disk=16G"
+    constraints: "cores=2 mem=8G root-disk=16G"
     annotations:
       "gui-x": "90"
       "gui-y": "850"
@@ -42,7 +42,7 @@ applications:
     num_units: 3
     options:
       channel: 3.4/stable
-    constraints: "root-disk=8G"
+    constraints: "cores=2 mem=8G root-disk=16G"
     annotations:
       "gui-x": "800"
       "gui-y": "420"

--- a/fragments/k8s/core/bundle.yaml
+++ b/fragments/k8s/core/bundle.yaml
@@ -9,9 +9,8 @@ applications:
     to:
       - "0"
     options:
-      channel: 1.23/edge
+      channel: 1.24/edge
     expose: true
-    constraints: "cores=2 mem=4G root-disk=16G"
     annotations:
       "gui-x": "800"
       "gui-y": "850"
@@ -29,9 +28,8 @@ applications:
     to:
       - "1"
     options:
-      channel: 1.23/edge
+      channel: 1.24/edge
     expose: true
-    constraints: "cores=4 mem=4G root-disk=16G"
     annotations:
       "gui-x": "90"
       "gui-y": "850"
@@ -59,7 +57,7 @@ relations:
 machines:
   "0":
     series: focal
-    constraints: "cores=2 mem=4G root-disk=16G"
+    constraints: "cores=2 mem=8G root-disk=16G"
   "1":
     series: focal
-    constraints: "cores=4 mem=4G root-disk=16G"
+    constraints: "cores=2 mem=8G root-disk=16G"

--- a/fragments/k8s/core/bundle.yaml
+++ b/fragments/k8s/core/bundle.yaml
@@ -11,7 +11,7 @@ applications:
     options:
       channel: 1.24/edge
     expose: true
-    constraints: "cores=4 mem=8G root-disk=16G"
+    constraints: "cores=2 mem=8G root-disk=16G"
     annotations:
       "gui-x": "800"
       "gui-y": "850"
@@ -31,7 +31,7 @@ applications:
     options:
       channel: 1.24/edge
     expose: true
-    constraints: "cores=4 mem=8G root-disk=16G"
+    constraints: "cores=2 mem=8G root-disk=16G"
     annotations:
       "gui-x": "90"
       "gui-y": "850"

--- a/fragments/k8s/core/bundle.yaml
+++ b/fragments/k8s/core/bundle.yaml
@@ -11,6 +11,7 @@ applications:
     options:
       channel: 1.24/edge
     expose: true
+    constraints: "cores=4 mem=8G root-disk=16G"
     annotations:
       "gui-x": "800"
       "gui-y": "850"
@@ -30,6 +31,7 @@ applications:
     options:
       channel: 1.24/edge
     expose: true
+    constraints: "cores=4 mem=8G root-disk=16G"
     annotations:
       "gui-x": "90"
       "gui-y": "850"


### PR DESCRIPTION
In preparation of the 1.24 release, revisit our bundle defaults to use `1.24/edge` snaps and adjust hardware constraints.

- Bump etcd reqs to [small cluster](https://etcd.io/docs/v3.3/op-guide/hardware/#small-cluster) recommendation
- Bump k-c-p and worker mem to 8G. I took some cues from [openshift reqs](https://docs.openshift.com/container-platform/3.11/install/prerequisites.html) -- a bit smaller for our control plane, a bit bigger for our workers.
- Bump all root-disks to 16GB; 8 was cutting it too close for long-running clusters (/var/log fills up)

Note: we don't specify charm channels in these yamls because our bundle builder injects those.