### PR TITLE
Revert "update overlays to reference 1.24/stable charms"

### DIFF
--- a/overlays/aws-overlay.yaml
+++ b/overlays/aws-overlay.yaml
@@ -4,9 +4,9 @@ applications:
     annotations:
       gui-x: "600"
       gui-y: "300"
-    charm: aws-integrator
+    charm: cs:~containers/aws-integrator
     num_units: 1
     trust: true
 relations:
-  - ['aws-integrator', 'kubernetes-control-plane']
+  - ['aws-integrator', 'kubernetes-master']
   - ['aws-integrator', 'kubernetes-worker']

--- a/overlays/azure-overlay.yaml
+++ b/overlays/azure-overlay.yaml
@@ -4,9 +4,9 @@ applications:
     annotations:
       gui-x: "600"
       gui-y: "300"
-    charm: azure-integrator
+    charm: cs:~containers/azure-integrator
     num_units: 1
     trust: true
 relations:
-  - ['azure-integrator', 'kubernetes-control-plane:azure']
+  - ['azure-integrator', 'kubernetes-master:azure']
   - ['azure-integrator', 'kubernetes-worker:azure']

--- a/overlays/bdc-overlay.yaml
+++ b/overlays/bdc-overlay.yaml
@@ -5,7 +5,7 @@ machines:
   '1':
     constraints: cores=8 mem=64G root-disk=100G
 applications:
-  kubernetes-control-plane:
+  kubernetes-master:
     options:
       allow-privileged: 'True'
  

--- a/overlays/calico-overlay.yaml
+++ b/overlays/calico-overlay.yaml
@@ -4,12 +4,12 @@ applications:
     annotations:
       gui-x: '480'
       gui-y: '750'
-    charm: calico
+    charm: cs:~containers/calico
   flannel:
 relations:
 - - calico:etcd
   - etcd:db
 - - calico:cni
-  - kubernetes-control-plane:cni
+  - kubernetes-master:cni
 - - calico:cni
   - kubernetes-worker:cni

--- a/overlays/canal-overlay.yaml
+++ b/overlays/canal-overlay.yaml
@@ -4,12 +4,12 @@ applications:
     annotations:
       gui-x: '450'
       gui-y: '750'
-    charm: canal
+    charm: cs:~containers/canal
   flannel:
 relations:
 - - canal:etcd
   - etcd:db
 - - canal:cni
-  - kubernetes-control-plane:cni
+  - kubernetes-master:cni
 - - canal:cni
   - kubernetes-worker:cni

--- a/overlays/ceph-fs.yaml
+++ b/overlays/ceph-fs.yaml
@@ -17,5 +17,5 @@ applications:
 relations:
   - ['ceph-fs:ceph-mds', 'ceph-mon:mds']
   - ['ceph-osd:mon', 'ceph-mon:osd']
-  - ['ceph-mon:admin', 'kubernetes-control-plane']
-  - ['ceph-mon:client', 'kubernetes-control-plane']
+  - ['ceph-mon:admin', 'kubernetes-master']
+  - ['ceph-mon:client', 'kubernetes-master']

--- a/overlays/ceph-rbd.yaml
+++ b/overlays/ceph-rbd.yaml
@@ -11,5 +11,5 @@ applications:
     num_units: 3
 relations:
   - ['ceph-osd:mon', 'ceph-mon:osd']
-  - ['ceph-mon:admin', 'kubernetes-control-plane']
-  - ['ceph-mon:client', 'kubernetes-control-plane']
+  - ['ceph-mon:admin', 'kubernetes-master']
+  - ['ceph-mon:client', 'kubernetes-master']

--- a/overlays/equinix-overlay.yaml
+++ b/overlays/equinix-overlay.yaml
@@ -7,7 +7,7 @@ machines:
     constraints: mem=32G
 applications:
   calico:
-    charm: calico
+    charm: cs:~containers/calico
     annotations:
       gui-x: '450'
       gui-y: '750'
@@ -83,7 +83,7 @@ applications:
       "": alpha
     to:
     - lxd:1
-  kubernetes-control-plane:
+  kubernetes-master:
     options:
       authorization-mode: "RBAC,Node"
       channel: 1.22/stable
@@ -125,18 +125,20 @@ relations:
 - - 'calico:etcd'
   - 'etcd:db'
 - - 'calico:cni'
-  - 'kubernetes-control-plane:cni'
+  - 'kubernetes-master:cni'
 - - 'calico:cni'
   - 'kubernetes-worker:cni'
-- - 'kubernetes-control-plane:ceph-client'
+- - 'kubernetes-master:ceph-storage'
+  - 'ceph-mon:admin'
+- - 'kubernetes-master:ceph-client'
   - 'ceph-mon:client'
 - - 'ceph-mon:radosgw'
   - 'ceph-radosgw:mon'
 - - 'ceph-fs:ceph-mds'
   - 'ceph-mon:mds'
-- - 'kubernetes-control-plane:kube-api-endpoint'
+- - 'kubernetes-master:kube-api-endpoint'
   - 'kubeapi-load-balancer:apiserver'
 - - 'kubeapi-load-balancer:loadbalancer'
-  - 'kubernetes-control-plane:loadbalancer'
+  - 'kubernetes-master:loadbalancer'
 - - 'kubeapi-load-balancer:website'
   - 'kubernetes-worker:kube-api-endpoint'

--- a/overlays/gcp-overlay.yaml
+++ b/overlays/gcp-overlay.yaml
@@ -4,9 +4,9 @@ applications:
     annotations:
       gui-x: "600"
       gui-y: "300"
-    charm: gcp-integrator
+    charm: cs:~containers/gcp-integrator
     num_units: 1
     trust: true
 relations:
-  - ['gcp-integrator', 'kubernetes-control-plane']
+  - ['gcp-integrator', 'kubernetes-master']
   - ['gcp-integrator', 'kubernetes-worker']

--- a/overlays/ipv4-ipv6-overlay.yaml
+++ b/overlays/ipv4-ipv6-overlay.yaml
@@ -3,6 +3,6 @@ applications:
   calico:
     options:
       cidr: "192.168.0.0/16,fd00:c00b:1::/112"
-  kubernetes-control-plane:
+  kubernetes-master:
     options:
       service-cidr: "10.152.183.0/24,fd00:c00b:2::/112"

--- a/overlays/logging-egf-overlay.yaml
+++ b/overlays/logging-egf-overlay.yaml
@@ -31,6 +31,6 @@ relations:
   - ["apache2:reverseproxy", "graylog:website"]
   - ["graylog:elasticsearch", "elasticsearch:client"]
   - ["graylog:mongodb", "mongodb:database"]
-  - ["filebeat:beats-host", "kubernetes-control-plane:juju-info"]
+  - ["filebeat:beats-host", "kubernetes-master:juju-info"]
   - ["filebeat:beats-host", "kubernetes-worker:juju-info"]
   - ["filebeat:logstash", "graylog:beats"]

--- a/overlays/monitoring-pgt-overlay.yaml
+++ b/overlays/monitoring-pgt-overlay.yaml
@@ -12,10 +12,10 @@ applications:
 relations:
   - [prometheus:grafana-source, grafana:grafana-source]
   - [telegraf:prometheus-client, prometheus:target]
-  - [kubernetes-control-plane:juju-info, telegraf:juju-info]
+  - [kubernetes-master:juju-info, telegraf:juju-info]
   - [kubernetes-worker:juju-info, telegraf:juju-info]
-  - [kubernetes-control-plane:prometheus, prometheus:manual-jobs]
-  - [kubernetes-control-plane:grafana, grafana:dashboards]
+  - [kubernetes-master:prometheus, prometheus:manual-jobs]
+  - [kubernetes-master:grafana, grafana:dashboards]
   - [prometheus:certificates, easyrsa:client]
   - [etcd:grafana, grafana:dashboards]
   - [etcd:prometheus, prometheus:manual-jobs]

--- a/overlays/openstack-lb-overlay.yaml
+++ b/overlays/openstack-lb-overlay.yaml
@@ -4,11 +4,11 @@ applications:
     annotations:
       gui-x: "600"
       gui-y: "300"
-    charm: openstack-integrator
+    charm: cs:~containers/openstack-integrator
     num_units: 1
     trust: true
 relations:
-  - ['kubernetes-control-plane:kube-api-endpoint', 'kubernetes-worker:kube-api-endpoint']
-  - ['openstack-integrator', 'kubernetes-control-plane:loadbalancer']
-  - ['openstack-integrator', 'kubernetes-control-plane:openstack']
+  - ['kubernetes-master:kube-api-endpoint', 'kubernetes-worker:kube-api-endpoint']
+  - ['openstack-integrator', 'kubernetes-master:loadbalancer']
+  - ['openstack-integrator', 'kubernetes-master:openstack']
   - ['openstack-integrator', 'kubernetes-worker:openstack']

--- a/overlays/openstack-overlay.yaml
+++ b/overlays/openstack-overlay.yaml
@@ -4,9 +4,9 @@ applications:
     annotations:
       gui-x: "600"
       gui-y: "300"
-    charm: openstack-integrator
+    charm: cs:~containers/openstack-integrator
     num_units: 1
     trust: true
 relations:
-  - ['openstack-integrator', 'kubernetes-control-plane:openstack']
+  - ['openstack-integrator', 'kubernetes-master:openstack']
   - ['openstack-integrator', 'kubernetes-worker:openstack']

--- a/overlays/tigera-overlay.yaml
+++ b/overlays/tigera-overlay.yaml
@@ -4,14 +4,14 @@ applications:
     annotations:
       gui-x: '450'
       gui-y: '750'
-    charm: tigera-secure-ee
+    charm: cs:~containers/tigera-secure-ee
   flannel:
 relations:
 - - tigera-secure-ee:etcd
   - etcd:db
 - - tigera-secure-ee:cni
-  - kubernetes-control-plane:cni
+  - kubernetes-master:cni
 - - tigera-secure-ee:cni
   - kubernetes-worker:cni
 - - tigera-secure-ee:kube-api-endpoint
-  - kubernetes-control-plane:kube-api-endpoint
+  - kubernetes-master:kube-api-endpoint

--- a/overlays/vault-pki-ha-overlay.yaml
+++ b/overlays/vault-pki-ha-overlay.yaml
@@ -9,7 +9,7 @@ applications:
     charm: percona-cluster
     num_units: 1
 relations:
-- - kubernetes-control-plane:certificates
+- - kubernetes-master:certificates
   - vault:certificates
 - - etcd:certificates
   - vault:certificates

--- a/overlays/vault-pki-overlay.yaml
+++ b/overlays/vault-pki-overlay.yaml
@@ -9,7 +9,7 @@ applications:
     charm: percona-cluster
     num_units: 1
 relations:
-- - kubernetes-control-plane:certificates
+- - kubernetes-master:certificates
   - vault:certificates
 - - etcd:certificates
   - vault:certificates

--- a/overlays/vsphere-overlay.yaml
+++ b/overlays/vsphere-overlay.yaml
@@ -4,9 +4,9 @@ applications:
     annotations:
       gui-x: "600"
       gui-y: "300"
-    charm: vsphere-integrator
+    charm: cs:~containers/vsphere-integrator
     num_units: 1
     trust: true
 relations:
-  - ['vsphere-integrator', 'kubernetes-control-plane']
+  - ['vsphere-integrator', 'kubernetes-master']
   - ['vsphere-integrator', 'kubernetes-worker']


### PR DESCRIPTION
Reverts charmed-kubernetes/bundle#833

Wrong branch; this needs to go to main and then cherry-pick to stable.