### PR TITLE
Remove kube-api-endpoint relation from openstack overlay

### DIFF
--- a/overlays/openstack-lb-overlay.yaml
+++ b/overlays/openstack-lb-overlay.yaml
@@ -8,7 +8,6 @@ applications:
     num_units: 1
     trust: true
 relations:
-  - ['kubernetes-control-plane:kube-api-endpoint', 'kubernetes-worker:kube-api-endpoint']
   - ['openstack-integrator', 'kubernetes-control-plane:loadbalancer']
   - ['openstack-integrator', 'kubernetes-control-plane:openstack']
   - ['openstack-integrator', 'kubernetes-worker:openstack']


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charmed-kubernetes-bundles/+bug/1974280