### PR TITLE
update vault overlays

### DIFF
--- a/overlays/vault-pki-ha-overlay.yaml
+++ b/overlays/vault-pki-ha-overlay.yaml
@@ -1,21 +1,39 @@
 applications:
-  easyrsa: null
+  mysql-innodb-cluster:
+    channel: 8.0/stable
+    charm: mysql-innodb-cluster
+    constraints: cores=2 mem=8G root-disk=64G
+    num_units: 3
+    options:
+      enable-binlogs: true
+      innodb-buffer-pool-size: 256M
+      max-connections: 2000
+      wait-timeout: 3600
   vault:
+    channel: 1.7/stable
     charm: vault
-    num_units: 2
+    num_units: 3
     options:
       auto-generate-root-ca-cert: true
-  percona-cluster:
-    charm: percona-cluster
-    num_units: 1
+  vault-hacluster:
+    charm: hacluster
+    options:
+      cluster_count: 3
+  vault-mysql-router:
+    channel: 8.0/stable
+    charm: mysql-router
 relations:
-- - kubernetes-control-plane:certificates
+- - etcd:db
+  - vault:etcd
+- - kubeapi-load-balancer:certificates
   - vault:certificates
-- - etcd:certificates
+- - kubernetes-control-plane:certificates
   - vault:certificates
 - - kubernetes-worker:certificates
   - vault:certificates
-- - vault:shared-db
-  - percona-cluster:shared-db
-- - vault:etcd
-  - etcd:db
+- - mysql-innodb-cluster:db-router
+  - vault-mysql-router:db-router
+- - vault-mysql-router:shared-db
+  - vault:shared-db
+- - vault-hacluster:ha
+  - vault:ha

--- a/overlays/vault-pki-overlay.yaml
+++ b/overlays/vault-pki-overlay.yaml
@@ -1,19 +1,34 @@
 applications:
   easyrsa: null
+  mysql-innodb-cluster:
+    channel: 8.0/stable
+    charm: mysql-innodb-cluster
+    constraints: cores=2 mem=8G root-disk=64G
+    num_units: 3
+    options:
+      enable-binlogs: true
+      innodb-buffer-pool-size: 256M
+      max-connections: 2000
+      wait-timeout: 3600
   vault:
+    channel: 1.7/stable
     charm: vault
     num_units: 1
     options:
       auto-generate-root-ca-cert: true
-  percona-cluster:
-    charm: percona-cluster
-    num_units: 1
+  vault-mysql-router:
+    channel: 8.0/stable
+    charm: mysql-router
 relations:
-- - kubernetes-control-plane:certificates
-  - vault:certificates
 - - etcd:certificates
+  - vault:certificates
+- - kubeapi-load-balancer:certificates
+  - vault:certificates
+- - kubernetes-control-plane:certificates
   - vault:certificates
 - - kubernetes-worker:certificates
   - vault:certificates
-- - vault:shared-db
-  - percona-cluster:shared-db
+- - mysql-innodb-cluster:db-router
+  - vault-mysql-router:db-router
+- - vault-mysql-router:shared-db
+  - vault:shared-db

--- a/overlays/vault-storage-overlay.yaml
+++ b/overlays/vault-storage-overlay.yaml
@@ -1,0 +1,25 @@
+applications:
+  mysql-innodb-cluster:
+    channel: 8.0/stable
+    charm: mysql-innodb-cluster
+    constraints: cores=2 mem=8G root-disk=64G
+    num_units: 3
+    options:
+      enable-binlogs: true
+      innodb-buffer-pool-size: 256M
+      max-connections: 2000
+      wait-timeout: 3600
+  vault:
+    channel: 1.7/stable
+    charm: vault
+    num_units: 1
+  vault-mysql-router:
+    channel: 8.0/stable
+    charm: mysql-router
+relations:
+- - kubernetes-control-plane:vault-kv
+  - vault:secrets
+- - mysql-innodb-cluster:db-router
+  - vault-mysql-router:db-router
+- - vault-mysql-router:shared-db
+  - vault:shared-db


### PR DESCRIPTION
Our vault overlays offer a bionic-only backend.  Update these for focal using `mysql-innodb-cluster` instead of `percona-cluster`.

Update the pki-ha overlay to include HA requirements from the [Charmed Openstack HA App guidelines](https://docs.openstack.org/charm-guide/latest/admin/ha.html#ha-applications). Note: in this scenario, `easyrsa` is required to bootstrap `etcd` for use by `vault`, hence the overlay does not remove the `easyrsa` application.

Also add a new storage overlay for people that want a secure db without the pki cert stuff.

Fixes https://bugs.launchpad.net/charmed-kubernetes-bundles/+bug/1946290