### PR TITLE
Fix Canal overlay not removing Calico

### DIFF
--- a/overlays/canal-overlay.yaml
+++ b/overlays/canal-overlay.yaml
@@ -5,7 +5,7 @@ applications:
       gui-x: '450'
       gui-y: '750'
     charm: canal
-  flannel:
+  calico:
 relations:
 - - canal:etcd
   - etcd:db


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charmed-kubernetes-bundles/+bug/1980084

Starting with Charmed Kubernetes 1.24 the default CNI implementation is Calico. The Canal overlay needs to remove Calico, not Flannel.