### PR TITLE
Add kube-ovn-overlay.yaml

### DIFF
--- a/overlays/kube-ovn-overlay.yaml
+++ b/overlays/kube-ovn-overlay.yaml
@@ -1,0 +1,11 @@
+description: Charmed Kubernetes overlay to add Kube-OVN CNI.
+applications:
+  calico: null
+  kube-ovn:
+    charm: kube-ovn
+  kubernetes-control-plane:
+    options:
+      allow-privileged: "true"
+relations:
+- [kube-ovn:cni, kubernetes-control-plane:cni]
+- [kube-ovn:cni, kubernetes-worker:cni]


### PR DESCRIPTION
This is needed for the Kube-OVN documentation.

This overlay doesn't work yet, but should work once we get a kube-ovn charm release out to stable.