### PR TITLE
make 1.25/stable the default snap channel for release_1.25

### DIFF
--- a/fragments/k8s/cdk-converged/bundle.yaml
+++ b/fragments/k8s/cdk-converged/bundle.yaml
@@ -22,7 +22,7 @@ applications:
     charm: "kubernetes-control-plane"
     num_units: 3
     options:
-      channel: 1.25/edge
+      channel: 1.25/stable
     annotations:
       "gui-x": "800"
       "gui-y": "850"
@@ -52,7 +52,7 @@ applications:
     constraints: cores=2 mem=4G root-disk=30G
     num_units: 12
     options:
-      channel: 1.25/edge
+      channel: 1.25/stable
     expose: true
     annotations:
       "gui-x": "90"

--- a/fragments/k8s/cdk/bundle.yaml
+++ b/fragments/k8s/cdk/bundle.yaml
@@ -10,7 +10,7 @@ applications:
     charm: "kubernetes-control-plane"
     num_units: 2
     options:
-      channel: 1.25/edge
+      channel: 1.25/stable
     constraints: "cores=2 mem=8G root-disk=16G"
     annotations:
       "gui-x": "800"
@@ -34,7 +34,7 @@ applications:
     charm: "kubernetes-worker"
     num_units: 3
     options:
-      channel: 1.25/edge
+      channel: 1.25/stable
     expose: true
     constraints: "cores=2 mem=8G root-disk=16G"
     annotations:

--- a/fragments/k8s/core/bundle.yaml
+++ b/fragments/k8s/core/bundle.yaml
@@ -12,7 +12,7 @@ applications:
     to:
       - "0"
     options:
-      channel: 1.25/edge
+      channel: 1.25/stable
     expose: true
     constraints: "cores=2 mem=8G root-disk=16G"
     annotations:
@@ -32,7 +32,7 @@ applications:
     to:
       - "1"
     options:
-      channel: 1.25/edge
+      channel: 1.25/stable
     expose: true
     constraints: "cores=2 mem=8G root-disk=16G"
     annotations:


### PR DESCRIPTION
In preparation for the 1.25 release, make 1.25/stable the default snap channel in the release branch.