### PR TITLE
update pgt overlay with current recommendations

### DIFF
--- a/overlays/monitoring-pgt-overlay.yaml
+++ b/overlays/monitoring-pgt-overlay.yaml
@@ -1,5 +1,6 @@
 applications:
   prometheus:
+    series: focal
     charm: prometheus2
     constraints: "mem=4G root-disk=16G"
     num_units: 1
@@ -13,9 +14,10 @@ relations:
   - [prometheus:grafana-source, grafana:grafana-source]
   - [telegraf:prometheus-client, prometheus:target]
   - [kubernetes-control-plane:juju-info, telegraf:juju-info]
-  - [kubernetes-worker:juju-info, telegraf:juju-info]
   - [kubernetes-control-plane:prometheus, prometheus:manual-jobs]
   - [kubernetes-control-plane:grafana, grafana:dashboards]
   - [prometheus:certificates, easyrsa:client]
+  - [kubernetes-worker:juju-info, telegraf:juju-info]
+  - [kubernetes-worker:scrape, prometheus:scrape]
   - [etcd:grafana, grafana:dashboards]
   - [etcd:prometheus, prometheus:manual-jobs]


### PR DESCRIPTION
Couple tweaks in our monitoring overlay came in via https://github.com/charmed-kubernetes/kubernetes-docs/pull/722.  I've confirmed these changes look good with the latest 1.25+ck1 bundle.