### PR TITLE
Fix typo in ceph-osd charm config

### DIFF
--- a/overlays/ceph-radosgw.yaml
+++ b/overlays/ceph-radosgw.yaml
@@ -7,7 +7,7 @@ applications:
     charm: ceph-osd
     num_units: 3
     storage:
-      ods-device: '32G,2'
+      osd-devices: '32G,2'
       osd-journals: '8G,1'
   ceph-mon:
     charm: ceph-mon


### PR DESCRIPTION
This PR fixes a typo in the applications.ceph-osd.storage.osd-devices config line that prevented the charm from installing.

From `ods-device`: to `ods-devices`.

This file is directly referenced in the Equinix Metal Charmed Kubernetes documentation here: https://ubuntu.com/kubernetes/docs/equinix

Signed-off-by: Chris Privitere <23177737+cprivitere@users.noreply.github.com>