### PR TITLE
Update snap channel to 1.27/edge

### DIFF
--- a/fragments/k8s/cdk-converged/bundle.yaml
+++ b/fragments/k8s/cdk-converged/bundle.yaml
@@ -22,7 +22,7 @@ applications:
     charm: "kubernetes-control-plane"
     num_units: 3
     options:
-      channel: 1.26/edge
+      channel: 1.27/edge
     annotations:
       "gui-x": "800"
       "gui-y": "850"
@@ -52,7 +52,7 @@ applications:
     constraints: cores=2 mem=4G root-disk=30G
     num_units: 12
     options:
-      channel: 1.26/edge
+      channel: 1.27/edge
     expose: true
     annotations:
       "gui-x": "90"

--- a/fragments/k8s/cdk/bundle.yaml
+++ b/fragments/k8s/cdk/bundle.yaml
@@ -10,7 +10,7 @@ applications:
     charm: "kubernetes-control-plane"
     num_units: 2
     options:
-      channel: 1.26/edge
+      channel: 1.27/edge
     constraints: "cores=2 mem=8G root-disk=16G"
     annotations:
       "gui-x": "800"
@@ -34,7 +34,7 @@ applications:
     charm: "kubernetes-worker"
     num_units: 3
     options:
-      channel: 1.26/edge
+      channel: 1.27/edge
     expose: true
     constraints: "cores=2 mem=8G root-disk=16G"
     annotations:

--- a/fragments/k8s/core/bundle.yaml
+++ b/fragments/k8s/core/bundle.yaml
@@ -12,7 +12,7 @@ applications:
     to:
       - "0"
     options:
-      channel: 1.26/edge
+      channel: 1.27/edge
     expose: true
     constraints: "cores=2 mem=8G root-disk=16G"
     annotations:
@@ -32,7 +32,7 @@ applications:
     to:
       - "1"
     options:
-      channel: 1.26/edge
+      channel: 1.27/edge
     expose: true
     constraints: "cores=2 mem=8G root-disk=16G"
     annotations:


### PR DESCRIPTION
Related to https://bugs.launchpad.net/bugs/2007162

I would say the main branches and latest/edge channels mostly represent development for k8s 1.27 at this point, so I propose we update the charm and bundle defaults to 1.27/edge.