### PR TITLE
Add cilium fragments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,14 @@ default: clean
 	./bundle k8s/core cni/canal monitor/elastic -o ./bundles/core-canal-elastic
 	./bundle k8s/cdk-converged cni/canal -o ./bundles/cdk-converged-canal
 	./bundle k8s/cdk-converged cni/canal legacy-storage/ceph -o ./bundles/cdk-converged-canal-ceph
+	./bundle k8s/cdk cni/cilium -o ./bundles/cdk-cilium
+	./bundle k8s/cdk cni/cilium legacy-storage/ceph -o ./bundles/cdk-cilium-ceph
+	./bundle k8s/cdk cni/cilium monitor/elastic -o ./bundles/cdk-cilium-elastic
+	./bundle k8s/core cni/cilium -o ./bundles/core-cilium
+	./bundle k8s/core cni/cilium monitor/elastic -o ./bundles/core-cilium-elastic
+	./bundle k8s/cdk-converged cni/cilium -o ./bundles/cdk-converged-cilium
+	./bundle k8s/cdk-converged cni/cilium legacy-storage/ceph -o ./bundles/cdk-converged-cilium-ceph
+
 
 clean:
 	rm -rf ./bundles

--- a/fragments/cni/cilium/README.md
+++ b/fragments/cni/cilium/README.md
@@ -1,0 +1,5 @@
+# Cilium
+
+A Kubernetes CNI solution developed on top of eBPF
+
+Cilium is open source software for transparently securing the network connectivity between application services deployed using Linux container management platforms. At the foundation of Cilium is a new Linux kernel technology called eBPF, which enables the dynamic insertion of powerful security visibility and control logic within Linux itself.

--- a/fragments/cni/cilium/bundle.yaml
+++ b/fragments/cni/cilium/bundle.yaml
@@ -1,0 +1,10 @@
+# This is an incomplete bundle fragment. Do not attempt to deploy.
+applications:
+  "cilium":
+    charm: "cilium"
+    annotations:
+      "gui-x": "475"
+      "gui-y": "605"
+relations:
+- [cilium:cni, kubernetes-control-plane:cni]
+- [cilium:cni, kubernetes-worker:cni]


### PR DESCRIPTION
The fragments for cilium in 1.27 isn't here.

```
bob@bob:/tmp/bundle$ ./bundle --channel=1.27/stable "k8s/cdk" "cni/cilium" "cri/containerd" -o "/tmp/bob"
Traceback (most recent call last):
  File "/tmp/bundle/./bundle", line 329, in <module>
    main()
  File "/tmp/bundle/./bundle", line 254, in main
    validate_components(args.fragments)
  File "/tmp/bundle/./bundle", line 81, in validate_components
    raise FragmentUnknown('Unknown fragment ' + frag)
__main__.FragmentUnknown: Unknown fragment cni/cilium

```

Added, and updated the Makefile

```
$ ./bundle --channel=1.27/stable "k8s/cdk" "cni/cilium" "cri/containerd" -o "/tmp/bob"
Processing fragment k8s/cdk...
Processing fragment cni/cilium...
Processing fragment cri/containerd...
Done. Your bundle can be found in /tmp/bob

```



