### PR TITLE
update fragments to point to 1.29/edge snap channels

### DIFF
--- a/fragments/k8s/cdk-converged/README.md
+++ b/fragments/k8s/cdk-converged/README.md
@@ -1,6 +1,6 @@
 # The Charmed Distribution of Kubernetes (converged)
 
-![](https://img.shields.io/badge/kubernetes-1.28-brightgreen.svg) 
+![](https://img.shields.io/badge/kubernetes-1.29-brightgreen.svg)
 ![](https://img.shields.io/badge/juju-2.9+-brightgreen.svg)
 ![](https://img.shields.io/badge/juju-3.1+-brightgreen.svg)
 

--- a/fragments/k8s/cdk-converged/bundle.yaml
+++ b/fragments/k8s/cdk-converged/bundle.yaml
@@ -22,7 +22,7 @@ applications:
     charm: "kubernetes-control-plane"
     num_units: 3
     options:
-      channel: 1.28/edge
+      channel: 1.29/edge
     annotations:
       "gui-x": "800"
       "gui-y": "850"
@@ -52,7 +52,7 @@ applications:
     constraints: cores=2 mem=4G root-disk=30G
     num_units: 12
     options:
-      channel: 1.28/edge
+      channel: 1.29/edge
     expose: true
     annotations:
       "gui-x": "90"

--- a/fragments/k8s/cdk/README.md
+++ b/fragments/k8s/cdk/README.md
@@ -1,6 +1,6 @@
 # Charmed Kubernetes
 
-![](https://img.shields.io/badge/kubernetes-1.28-brightgreen.svg) 
+![](https://img.shields.io/badge/kubernetes-1.29-brightgreen.svg)
 ![](https://img.shields.io/badge/juju-2.9+-brightgreen.svg)
 ![](https://img.shields.io/badge/juju-3.1+-brightgreen.svg)
 

--- a/fragments/k8s/cdk/bundle.yaml
+++ b/fragments/k8s/cdk/bundle.yaml
@@ -10,7 +10,7 @@ applications:
     charm: "kubernetes-control-plane"
     num_units: 2
     options:
-      channel: 1.28/edge
+      channel: 1.29/edge
     constraints: "cores=2 mem=8G root-disk=16G"
     annotations:
       "gui-x": "800"
@@ -34,7 +34,7 @@ applications:
     charm: "kubernetes-worker"
     num_units: 3
     options:
-      channel: 1.28/edge
+      channel: 1.29/edge
     expose: true
     constraints: "cores=2 mem=8G root-disk=16G"
     annotations:

--- a/fragments/k8s/core/README.md
+++ b/fragments/k8s/core/README.md
@@ -1,6 +1,6 @@
 # Kubernetes Core Bundle
 
-![](https://img.shields.io/badge/kubernetes-1.28-brightgreen.svg) 
+![](https://img.shields.io/badge/kubernetes-1.29-brightgreen.svg)
 ![](https://img.shields.io/badge/juju-2.9+-brightgreen.svg)
 ![](https://img.shields.io/badge/juju-3.1+-brightgreen.svg)
 

--- a/fragments/k8s/core/bundle.yaml
+++ b/fragments/k8s/core/bundle.yaml
@@ -12,7 +12,7 @@ applications:
     to:
       - "0"
     options:
-      channel: 1.28/edge
+      channel: 1.29/edge
     expose: true
     constraints: "cores=2 mem=8G root-disk=16G"
     annotations:
@@ -32,7 +32,7 @@ applications:
     to:
       - "1"
     options:
-      channel: 1.28/edge
+      channel: 1.29/edge
     expose: true
     constraints: "cores=2 mem=8G root-disk=16G"
     annotations:


### PR DESCRIPTION
* bump snap channel defaults from 1.28/edge to 1.29/edge
* update bundle in the charm READMEs