### PR TITLE
[LP#1940328] Update openstack-integrator overlays for 1.29

### DIFF
--- a/overlays/openstack-lb-overlay.yaml
+++ b/overlays/openstack-lb-overlay.yaml
@@ -1,13 +1,25 @@
 applications:
-  kubeapi-load-balancer: null
+  kubeapi-load-balancer: null                            # excludes the kubeapi-load-balancer
+  kubernetes-control-plane:
+    options:
+      allow-privileged: "true"
   openstack-integrator:
     annotations:
-      gui-x: "600"
-      gui-y: "300"
     charm: openstack-integrator
     num_units: 1
     trust: true
+  openstack-cloud-controller:
+    charm: openstack-integrator
+    channel: edge
+  cinder-csi:
+    charm: cinder-csi
+    channel: edge
 relations:
-  - ['openstack-integrator', 'kubernetes-control-plane:loadbalancer']
-  - ['openstack-integrator', 'kubernetes-control-plane:openstack']
-  - ['openstack-integrator', 'kubernetes-worker:openstack']
+  - [openstack-cloud-controller:certificates,            easyrsa:client]
+  - [openstack-cloud-controller:kube-control,            kubernetes-control-plane:kube-control]
+  - [openstack-cloud-controller:external-cloud-provider, kubernetes-control-plane:external-cloud-provider]
+  - [openstack-cloud-controller:openstack,               openstack-integrator:clients]
+  - [easyrsa:client,                                     cinder-csi:certificates]
+  - [kubernetes-control-plane:kube-control,              cinder-csi:kube-control]
+  - [openstack-integrator:clients,                       cinder-csi:openstack, ]
+  - [kubernetes-control-plane:loadbalancer-external,     openstack-integrator:lb-consumer]

--- a/overlays/openstack-lb-overlay.yaml
+++ b/overlays/openstack-lb-overlay.yaml
@@ -10,10 +10,8 @@ applications:
     trust: true
   openstack-cloud-controller:
     charm: openstack-integrator
-    channel: edge
   cinder-csi:
     charm: cinder-csi
-    channel: edge
 relations:
   - [openstack-cloud-controller:certificates,            easyrsa:client]
   - [openstack-cloud-controller:kube-control,            kubernetes-control-plane:kube-control]

--- a/overlays/openstack-overlay.yaml
+++ b/overlays/openstack-overlay.yaml
@@ -9,10 +9,8 @@ applications:
     trust: true
   openstack-cloud-controller:
     charm: openstack-integrator
-    channel: edge
   cinder-csi:
     charm: cinder-csi
-    channel: edge
 relations:
   - [openstack-cloud-controller:certificates,            easyrsa:client]
   - [openstack-cloud-controller:kube-control,            kubernetes-control-plane:kube-control]

--- a/overlays/openstack-overlay.yaml
+++ b/overlays/openstack-overlay.yaml
@@ -1,12 +1,23 @@
-description: Charmed Kubernetes overlay to add native OpenStack support.
 applications:
+  kubernetes-control-plane:
+    options:
+      allow-privileged: "true"
   openstack-integrator:
     annotations:
-      gui-x: "600"
-      gui-y: "300"
     charm: openstack-integrator
     num_units: 1
     trust: true
+  openstack-cloud-controller:
+    charm: openstack-integrator
+    channel: edge
+  cinder-csi:
+    charm: cinder-csi
+    channel: edge
 relations:
-  - ['openstack-integrator', 'kubernetes-control-plane:openstack']
-  - ['openstack-integrator', 'kubernetes-worker:openstack']
+  - [openstack-cloud-controller:certificates,            easyrsa:client]
+  - [openstack-cloud-controller:kube-control,            kubernetes-control-plane:kube-control]
+  - [openstack-cloud-controller:external-cloud-provider, kubernetes-control-plane:external-cloud-provider]
+  - [openstack-cloud-controller:openstack,               openstack-integrator:clients]
+  - [easyrsa:client,                                     cinder-csi:certificates]
+  - [kubernetes-control-plane:kube-control,              cinder-csi:kube-control]
+  - [openstack-integrator:clients,                       cinder-csi:openstack, ]


### PR DESCRIPTION
[LP#1940328](https://bugs.launchpad.net/charm-openstack-integrator/+bug/1940328)

With the removal of the `loadbalancer` relation in the `kubernetes-control-plane`, the overlays to deploy on openstack need to be explicitly updated.