### PR TITLE
refresh bundle constraints

### DIFF
--- a/fragments/k8s/cdk-converged/README.md
+++ b/fragments/k8s/cdk-converged/README.md
@@ -1,7 +1,6 @@
 # The Charmed Distribution of Kubernetes (converged)
 
 ![](https://img.shields.io/badge/kubernetes-1.29-brightgreen.svg)
-![](https://img.shields.io/badge/juju-2.9+-brightgreen.svg)
 ![](https://img.shields.io/badge/juju-3.1+-brightgreen.svg)
 
 

--- a/fragments/k8s/cdk/README.md
+++ b/fragments/k8s/cdk/README.md
@@ -1,7 +1,6 @@
 # Charmed Kubernetes
 
 ![](https://img.shields.io/badge/kubernetes-1.29-brightgreen.svg)
-![](https://img.shields.io/badge/juju-2.9+-brightgreen.svg)
 ![](https://img.shields.io/badge/juju-3.1+-brightgreen.svg)
 
 

--- a/fragments/k8s/cdk/bundle.yaml
+++ b/fragments/k8s/cdk/bundle.yaml
@@ -11,7 +11,7 @@ applications:
     num_units: 2
     options:
       channel: 1.29/edge
-    constraints: "cores=2 mem=8G root-disk=16G"
+    constraints: "cores=2 mem=8G root-disk=64G"
     annotations:
       "gui-x": "800"
       "gui-y": "850"
@@ -19,14 +19,14 @@ applications:
     charm: "kubeapi-load-balancer"
     num_units: 1
     expose: true
-    constraints: "cores=1 mem=4G root-disk=16G"
+    constraints: "cores=1 mem=4G root-disk=64G"
     annotations:
       "gui-x": "450"
       "gui-y": "250"
   "easyrsa":
     charm: "easyrsa"
     num_units: 1
-    constraints: "cores=1 mem=4G root-disk=16G"
+    constraints: "cores=1 mem=4G root-disk=64G"
     annotations:
       "gui-x": "90"
       "gui-y": "420"
@@ -36,7 +36,7 @@ applications:
     options:
       channel: 1.29/edge
     expose: true
-    constraints: "cores=2 mem=8G root-disk=16G"
+    constraints: "cores=2 mem=8G root-disk=64G"
     annotations:
       "gui-x": "90"
       "gui-y": "850"
@@ -45,7 +45,7 @@ applications:
     num_units: 3
     options:
       channel: 3.4/stable
-    constraints: "cores=2 mem=8G root-disk=16G"
+    constraints: "cores=2 mem=8G root-disk=64G"
     annotations:
       "gui-x": "800"
       "gui-y": "420"

--- a/fragments/k8s/core/README.md
+++ b/fragments/k8s/core/README.md
@@ -1,7 +1,6 @@
 # Kubernetes Core Bundle
 
 ![](https://img.shields.io/badge/kubernetes-1.29-brightgreen.svg)
-![](https://img.shields.io/badge/juju-2.9+-brightgreen.svg)
 ![](https://img.shields.io/badge/juju-3.1+-brightgreen.svg)
 
 ## Overview

--- a/fragments/k8s/core/bundle.yaml
+++ b/fragments/k8s/core/bundle.yaml
@@ -14,7 +14,7 @@ applications:
     options:
       channel: 1.29/edge
     expose: true
-    constraints: "cores=2 mem=8G root-disk=16G"
+    constraints: "cores=4 mem=16G root-disk=64G"
     annotations:
       "gui-x": "800"
       "gui-y": "850"
@@ -34,7 +34,7 @@ applications:
     options:
       channel: 1.29/edge
     expose: true
-    constraints: "cores=2 mem=8G root-disk=16G"
+    constraints: "cores=2 mem=8G root-disk=64G"
     annotations:
       "gui-x": "90"
       "gui-y": "850"
@@ -61,6 +61,6 @@ relations:
     - "easyrsa:client"
 machines:
   "0":
-    constraints: "cores=2 mem=8G root-disk=16G"
+    constraints: "cores=4 mem=16G root-disk=64G"
   "1":
-    constraints: "cores=2 mem=8G root-disk=16G"
+    constraints: "cores=2 mem=8G root-disk=64G"


### PR DESCRIPTION
remove juju 2.9 badges; bump root-disks to 64G and double k-c-p cpu/mem in the core bundle