### PR TITLE
Fix typo in the relation name of lb-consumers

### DIFF
--- a/overlays/openstack-lb-overlay.yaml
+++ b/overlays/openstack-lb-overlay.yaml
@@ -19,4 +19,4 @@ relations:
   - [easyrsa:client,                                     cinder-csi:certificates]
   - [kubernetes-control-plane:kube-control,              cinder-csi:kube-control]
   - [openstack-integrator:clients,                       cinder-csi:openstack]
-  - [kubernetes-control-plane:loadbalancer-external,     openstack-integrator:lb-consumer]
+  - [kubernetes-control-plane:loadbalancer-external,     openstack-integrator:lb-consumers]


### PR DESCRIPTION
> ERROR cannot deploy bundle: cannot add relation between "kubernetes-control-plane:loadbalancer-external" and "openstack-integrator:lb-consumer": application "openstack-integrator" has no "lb-consumer" relation
