### PR TITLE
Use default-base rather than series

### DIFF
--- a/fragments/k8s/cdk-converged/bundle.yaml
+++ b/fragments/k8s/cdk-converged/bundle.yaml
@@ -1,7 +1,7 @@
 # This is an incomplete bundle fragment. Do not attempt to deploy.
 description: |-
     A seven-machine Kubernetes cluster, appropriate for bare metal using MaaS KVM Pods. Includes three kubernetes-control-plane and four worker nodes.
-series: jammy
+default-base: ubuntu@22.04
 machines:
   0:
     constraints: cores=8 mem=16G root-disk=100G

--- a/fragments/k8s/cdk/bundle.yaml
+++ b/fragments/k8s/cdk/bundle.yaml
@@ -2,7 +2,7 @@
 description: |-
     A highly-available, production-grade Kubernetes cluster.
 issues: https://bugs.launchpad.net/charmed-kubernetes-bundles
-series: jammy
+default-base: ubuntu@22.04
 source: https://github.com/charmed-kubernetes/bundle
 website: https://ubuntu.com/kubernetes/charmed-k8s
 applications:

--- a/fragments/k8s/core/bundle.yaml
+++ b/fragments/k8s/core/bundle.yaml
@@ -2,7 +2,7 @@
 description: |-
     A minimal two-machine Kubernetes cluster, appropriate for development.
 issues: https://bugs.launchpad.net/charmed-kubernetes-bundles
-series: jammy
+default-base: ubuntu@22.04
 source: https://github.com/charmed-kubernetes/bundle
 website: https://ubuntu.com/kubernetes/charmed-k8s
 applications:


### PR DESCRIPTION
## Overview

Rather than using `series`, use `default-base` in our charmed-kubernetes bundles

## Details

Since juju 3.1, the preferred method of specifying the machine version is to use bases rather than named series.  Now that charmed-kubernetes only supports juju 3, lets finally fix this
* Using this unlocks support for noble (ubuntu@24.04) -- deploying a bundle without a `default-base` sent the juju client off looking for a  base for the machines.  It encountered charms with bases the client didn't recognize that caused deployments to fail.