### PR TITLE
chore: 1.33 release readiness

### DIFF
--- a/fragments/k8s/cdk-converged/README.md
+++ b/fragments/k8s/cdk-converged/README.md
@@ -1,6 +1,6 @@
 # The Charmed Distribution of Kubernetes (converged)
 
-![](https://img.shields.io/badge/kubernetes-1.29-brightgreen.svg)
+![](https://img.shields.io/badge/kubernetes-1.33-brightgreen.svg)
 ![](https://img.shields.io/badge/juju-2.9+-brightgreen.svg)
 ![](https://img.shields.io/badge/juju-3.1+-brightgreen.svg)
 

--- a/fragments/k8s/cdk-converged/bundle.yaml
+++ b/fragments/k8s/cdk-converged/bundle.yaml
@@ -23,7 +23,7 @@ applications:
     charm: "kubernetes-control-plane"
     num_units: 3
     options:
-      channel: 1.29/edge
+      channel: 1.33/stable
     annotations:
       "gui-x": "800"
       "gui-y": "850"
@@ -53,7 +53,7 @@ applications:
     constraints: cores=2 mem=4G root-disk=30G
     num_units: 12
     options:
-      channel: 1.29/edge
+      channel: 1.33/stable
     expose: true
     annotations:
       "gui-x": "90"

--- a/fragments/k8s/cdk/bundle.yaml
+++ b/fragments/k8s/cdk/bundle.yaml
@@ -11,7 +11,7 @@ applications:
     charm: "kubernetes-control-plane"
     num_units: 2
     options:
-      channel: 1.33/edge
+      channel: 1.33/stable
     constraints: "cores=2 mem=8G root-disk=16G"
     annotations:
       "gui-x": "800"
@@ -35,7 +35,7 @@ applications:
     charm: "kubernetes-worker"
     num_units: 3
     options:
-      channel: 1.33/edge
+      channel: 1.33/stable
     expose: true
     constraints: "cores=2 mem=8G root-disk=16G"
     annotations:

--- a/fragments/k8s/core/bundle.yaml
+++ b/fragments/k8s/core/bundle.yaml
@@ -13,7 +13,7 @@ applications:
     to:
       - "0"
     options:
-      channel: 1.33/edge
+      channel: 1.33/stable
     expose: true
     constraints: "cores=2 mem=8G root-disk=16G"
     annotations:
@@ -33,7 +33,7 @@ applications:
     to:
       - "1"
     options:
-      channel: 1.33/edge
+      channel: 1.33/stable
     expose: true
     constraints: "cores=2 mem=8G root-disk=16G"
     annotations:


### PR DESCRIPTION
### Overview
This PR updates the k8s version according to the [release doc](https://github.com/charmed-kubernetes/jenkins/blob/main/docs/releases/stable/index.md#pin-snap-channel-for-charms-in-the-release-branches)