### PR TITLE
Allow for flexible base-selection within a model using overlays

### DIFF
--- a/fragments/k8s/cdk/bundle.yaml
+++ b/fragments/k8s/cdk/bundle.yaml
@@ -3,7 +3,6 @@ description: |-
     A highly-available, production-grade Kubernetes cluster.
 docs: https://discourse.charmhub.io/t/charmed-kubernetes-bundle/14447
 issues: https://bugs.launchpad.net/charmed-kubernetes-bundles
-default-base: ubuntu@22.04
 source: https://github.com/charmed-kubernetes/bundle
 website: https://ubuntu.com/kubernetes/charmed-k8s
 applications:

--- a/fragments/k8s/cdk/bundle.yaml
+++ b/fragments/k8s/cdk/bundle.yaml
@@ -3,6 +3,7 @@ description: |-
     A highly-available, production-grade Kubernetes cluster.
 docs: https://discourse.charmhub.io/t/charmed-kubernetes-bundle/14447
 issues: https://bugs.launchpad.net/charmed-kubernetes-bundles
+series: noble
 source: https://github.com/charmed-kubernetes/bundle
 website: https://ubuntu.com/kubernetes/charmed-k8s
 applications:

--- a/fragments/k8s/core/bundle.yaml
+++ b/fragments/k8s/core/bundle.yaml
@@ -3,6 +3,7 @@ description: |-
     A minimal two-machine Kubernetes cluster, appropriate for development.
 docs: https://discourse.charmhub.io/t/charmed-kubernetes-bundle/14447
 issues: https://bugs.launchpad.net/charmed-kubernetes-bundles
+series: noble
 source: https://github.com/charmed-kubernetes/bundle
 website: https://ubuntu.com/kubernetes/charmed-k8s
 applications:

--- a/fragments/k8s/core/bundle.yaml
+++ b/fragments/k8s/core/bundle.yaml
@@ -3,7 +3,6 @@ description: |-
     A minimal two-machine Kubernetes cluster, appropriate for development.
 docs: https://discourse.charmhub.io/t/charmed-kubernetes-bundle/14447
 issues: https://bugs.launchpad.net/charmed-kubernetes-bundles
-default-base: ubuntu@22.04
 source: https://github.com/charmed-kubernetes/bundle
 website: https://ubuntu.com/kubernetes/charmed-k8s
 applications:


### PR DESCRIPTION
WIP: Need to create a bug on JIRA for tracking

Description:
* If one sets the `default-base` in a bundle, nothing can be done to override this `default-base` in a bundle overlay.
* In order to test on both jammy and noble, we must remove the `default-base`
* without a overlay bundle, the base for each charm will follow the most recently supported LTS by the charm
    *  this seems to be part of juju that i've determined emperically
* I think there's a bug on juju where the `default-base` of a bundle should be allowed to be overridden.


Based on the discussion [here](https://matrix.to/#/!xzmWHtGpPfVCXKivIh:ubuntu.com/$f8P89MyMu-t7o_wYWiyd9LZryfvM9O6FmA-EPEICiEw?via=ubuntu.com&via=matrix.org&via=xentonix.net)